### PR TITLE
Fix gradio version for xray

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ contexttimer
 ipython
 pyyaml>=6
 pandas
-gradio
+gradio<5
 gitpython # for the reproducibility script
 requests


### PR DESCRIPTION
Gradio version >5 introduces a breaking change as explain PR #98. Changed the requirements to install a version lesser than 5.* and it fixes the issue.