### PR TITLE
Add unit test to test agentlab xray

### DIFF
--- a/src/agentlab/analyze/agent_xray.py
+++ b/src/agentlab/analyze/agent_xray.py
@@ -212,7 +212,12 @@ clicking the refresh button.
                 container=False,
                 elem_id="experiment_directory_dropdown",
             )
-            refresh_button = gr.Button("↺", scale=0, size="sm")
+            refresh_button = gr.Button(
+                "↺",
+                scale=0,
+                size="sm",
+                elem_id="refresh_button",
+            )
 
         with gr.Tabs():
             with gr.Tab("Select Agent"):
@@ -1198,6 +1203,7 @@ def plot_profiling(ax, step_info_list: list[StepInfo], summary_info: dict, progr
 
 def main(result_dir_path: str | None = None):
     if result_dir_path:
+        print(result_dir_path)
         run_gradio(Path(result_dir_path))
     else:
         run_gradio(RESULTS_DIR)

--- a/src/agentlab/analyze/agent_xray.py
+++ b/src/agentlab/analyze/agent_xray.py
@@ -1,3 +1,4 @@
+import argparse
 import base64
 import os
 import traceback
@@ -209,6 +210,7 @@ clicking the refresh button.
                 show_label=False,
                 scale=6,
                 container=False,
+                elem_id="experiment_directory_dropdown",
             )
             refresh_button = gr.Button("↺", scale=0, size="sm")
 
@@ -1194,9 +1196,15 @@ def plot_profiling(ax, step_info_list: list[StepInfo], summary_info: dict, progr
     return step_times
 
 
-def main():
-    run_gradio(RESULTS_DIR)
+def main(result_dir_path: str | None = None):
+    if result_dir_path:
+        run_gradio(Path(result_dir_path))
+    else:
+        run_gradio(RESULTS_DIR)
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--experiment_path", default=None, type=str, required=False)
+    args = parser.parse_args()
+    main(args.experiment_path)

--- a/tests/analyze/test_agentlab_xray.py
+++ b/tests/analyze/test_agentlab_xray.py
@@ -1,0 +1,74 @@
+from typing import Callable
+import os
+import pytest
+import subprocess
+import time
+
+from playwright.sync_api import sync_playwright, Page
+from pathlib import Path
+
+
+AGENTLAB_XRAY_URL = "http://127.0.0.1:7860"
+PATH_URL = Path("tests/data/test_study")
+TEST_EXPERIMENT_PATH = "tests/data/test_study"
+
+os.environ["AGENTXRAY_APP_PORT"] = "7860"
+
+
+def launch_gradio_app():
+    # Launch the Gradio app in a separate process
+    process = subprocess.Popen(
+        ["python", "src/agentlab/analyze/agent_xray.py", "--experiment_path", TEST_EXPERIMENT_PATH],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    print(process)
+    time.sleep(5)  # Wait for the app to start (adjust based on app startup time)
+    return process
+
+
+def stop_gradio_app(process: subprocess.Popen[bytes]):
+    # Terminate the Gradio app process
+    process.terminate()
+    process.wait()
+
+
+def run_playwright_with_test(test_function: Callable[[Page], None]):
+
+    # Launch the Gradio app
+    gradio_process = launch_gradio_app()
+
+    try:
+        # Use Playwright to test the app
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+
+            # Navigate to the Gradio app
+            page.goto(AGENTLAB_XRAY_URL)
+
+            test_function(page)
+
+            # Close the browser
+            browser.close()
+
+    finally:
+        # Stop the Gradio app
+        stop_gradio_app(gradio_process)
+
+
+@pytest.mark.playwright
+def test_clicking_dropdown():
+    """Check that the experiment directory dropdown can be clicked"""
+
+    def click_dropdown(page: Page):
+        dropdown = page.locator("#experiment_directory_dropdown")
+        dropdown.select_option(
+            "2024-08-01_10-20-52_GenericAgent_on_miniwob.ascending-numbers_68_b6312d"
+        )
+
+    run_playwright_with_test(click_dropdown)
+
+
+if __name__ == "__main__":
+    test_clicking_dropdown()

--- a/tests/analyze/test_agentlab_xray.py
+++ b/tests/analyze/test_agentlab_xray.py
@@ -22,8 +22,7 @@ def launch_gradio_app():
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
-    print(process)
-    time.sleep(5)  # Wait for the app to start (adjust based on app startup time)
+    time.sleep(10)  # Wait for the app to start (adjust based on app startup time)
     return process
 
 
@@ -63,12 +62,28 @@ def test_clicking_dropdown():
 
     def click_dropdown(page: Page):
         dropdown = page.locator("#experiment_directory_dropdown")
-        dropdown.select_option(
-            "2024-08-01_10-20-52_GenericAgent_on_miniwob.ascending-numbers_68_b6312d"
+        dropdown.click()
+
+        options_container = page.locator("ul[role='listbox']")
+        options_container.wait_for(state="visible", timeout=5000)
+        option_to_select = options_container.filter(
+            has_text="2024-08-01_10-20-52_GenericAgent_on_miniwob.ascending-numbers_68_b6312d"
         )
+        option_to_select.click()
 
     run_playwright_with_test(click_dropdown)
 
 
+@pytest.mark.playwright
+def test_refresh_button():
+    """Check that the refresh button can be clicked"""
+
+    def click_refresh(page: Page):
+        page.click("#refresh_button")
+
+    run_playwright_with_test(click_refresh)
+
+
 if __name__ == "__main__":
     test_clicking_dropdown()
+    test_refresh_button()


### PR DESCRIPTION
In this PR

Goal: Implement unit tests for agentlab-xray

Main Changes:
- `agent_xray.py`: Changed the main function to accept a new test directory from the passed arguments
- `test_agentlab_xray.py`: 
  - Test clicking dropdown – clicks dropdown and selects an option
  - Test clicking refresh button

To Do:
- The refresh button is buggy, for some reason, locator can't find the button by its elem_id
- (I'm not sure) but the filter function from Playwright doesn't work as I expect – when I changed the directory, the hardcoded folder name should not be there, so I expect it to fail when the option is clicked – but for some reason it goes through