### PR TITLE
limiting to python 3.11 and above

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
+        with: # python at least 3.11
+          python-version: '3.11'
           cache: 'pip' # caching pip dependencies
 
       - name: Install AgentLab

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ AgentLab Features:
 
 ## 🛠️ Setup AgentLab
 
+AgentLab requires python 3.11 or higher.
+
 ```bash
 pip install agentlab
 ```


### PR DESCRIPTION
limiting to python 3.11 and above

3.10 or below requires async-timeout pkg which breaks ray timeouts apparently