### PR TITLE
adding log_prob option for chat models

### DIFF
--- a/src/agentlab/__init__.py
+++ b/src/agentlab/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.4.0.dev0"
+__version__ = "v0.4.0"

--- a/src/agentlab/__init__.py
+++ b/src/agentlab/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.3.2"
+__version__ = "v0.3.2.dev0"

--- a/src/agentlab/__init__.py
+++ b/src/agentlab/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "v0.3.2.dev0"
+__version__ = "v0.4.0.dev0"

--- a/src/agentlab/llm/base_api.py
+++ b/src/agentlab/llm/base_api.py
@@ -21,6 +21,7 @@ class BaseModelArgs(ABC):
     max_new_tokens: int = None
     temperature: float = 0.1
     vision_support: bool = False
+    log_probs: bool = False
 
     @abstractmethod
     def make_model(self) -> AbstractChatModel:

--- a/src/agentlab/llm/chat_api.py
+++ b/src/agentlab/llm/chat_api.py
@@ -145,7 +145,7 @@ class SelfHostedModelArgs(BaseModelArgs):
                 temperature=self.temperature,
                 max_new_tokens=self.max_new_tokens,
                 n_retry_server=self.n_retry_server,
-                log_probs=self.log_probs
+                log_probs=self.log_probs,
             )
         else:
             raise ValueError(f"Backend {self.backend} is not supported")

--- a/src/agentlab/llm/chat_api.py
+++ b/src/agentlab/llm/chat_api.py
@@ -87,6 +87,7 @@ class OpenRouterModelArgs(BaseModelArgs):
             model_name=self.model_name,
             temperature=self.temperature,
             max_tokens=self.max_new_tokens,
+            log_probs=self.log_probs,
         )
 
 
@@ -100,6 +101,7 @@ class OpenAIModelArgs(BaseModelArgs):
             model_name=self.model_name,
             temperature=self.temperature,
             max_tokens=self.max_new_tokens,
+            log_probs=self.log_probs,
         )
 
 
@@ -115,6 +117,7 @@ class AzureModelArgs(BaseModelArgs):
             temperature=self.temperature,
             max_tokens=self.max_new_tokens,
             deployment_name=self.deployment_name,
+            log_probs=self.log_probs,
         )
 
 
@@ -225,6 +228,7 @@ class ChatModel(AbstractChatModel):
         client_class=OpenAI,
         client_args=None,
         pricing_func=None,
+        log_probs=False,
     ):
         assert max_retry > 0, "max_retry should be greater than 0"
 
@@ -233,6 +237,7 @@ class ChatModel(AbstractChatModel):
         self.max_tokens = max_tokens
         self.max_retry = max_retry
         self.min_retry_wait_time = min_retry_wait_time
+        self.logprobs = log_probs
 
         # Get the API key from the environment variable if not provided
         if api_key_env_var:
@@ -279,6 +284,7 @@ class ChatModel(AbstractChatModel):
                     n=n_samples,
                     temperature=temperature,
                     max_tokens=self.max_tokens,
+                    logprobs=self.logprobs,
                 )
 
                 if completion.usage is None:
@@ -308,7 +314,10 @@ class ChatModel(AbstractChatModel):
             tracking.TRACKER.instance(input_tokens, output_tokens, cost)
 
         if n_samples == 1:
-            return AIMessage(completion.choices[0].message.content)
+            res = AIMessage(completion.choices[0].message.content)
+            if self.logprobs:
+                res["logprobs"] = completion.choices[0].logprobs
+            return res
         else:
             return [AIMessage(c.message.content) for c in completion.choices]
 
@@ -328,6 +337,7 @@ class OpenAIChatModel(ChatModel):
         max_tokens=100,
         max_retry=4,
         min_retry_wait_time=60,
+        log_probs=False,
     ):
         super().__init__(
             model_name=model_name,
@@ -339,6 +349,7 @@ class OpenAIChatModel(ChatModel):
             api_key_env_var="OPENAI_API_KEY",
             client_class=OpenAI,
             pricing_func=tracking.get_pricing_openai,
+            log_probs=log_probs,
         )
 
 
@@ -351,6 +362,7 @@ class OpenRouterChatModel(ChatModel):
         max_tokens=100,
         max_retry=4,
         min_retry_wait_time=60,
+        log_probs=False,
     ):
         client_args = {
             "base_url": "https://openrouter.ai/api/v1",
@@ -366,6 +378,7 @@ class OpenRouterChatModel(ChatModel):
             client_class=OpenAI,
             client_args=client_args,
             pricing_func=tracking.get_pricing_openrouter,
+            log_probs=log_probs,
         )
 
 
@@ -379,6 +392,7 @@ class AzureChatModel(ChatModel):
         max_tokens=100,
         max_retry=4,
         min_retry_wait_time=60,
+        log_probs=False,
     ):
         api_key = api_key or os.getenv("AZURE_OPENAI_API_KEY")
         endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
@@ -399,6 +413,7 @@ class AzureChatModel(ChatModel):
             client_class=AzureOpenAI,
             client_args=client_args,
             pricing_func=tracking.get_pricing_openai,
+            log_probs=log_probs,
         )
 
 
@@ -412,6 +427,7 @@ class HuggingFaceURLChatModel(HFBaseChatModel):
         temperature: Optional[int] = 1e-1,
         max_new_tokens: Optional[int] = 512,
         n_retry_server: Optional[int] = 4,
+        log_probs: Optional[bool] = False,
     ):
         super().__init__(model_name, base_model_name, n_retry_server)
         if temperature < 1e-3:
@@ -422,4 +438,4 @@ class HuggingFaceURLChatModel(HFBaseChatModel):
             token = os.environ["TGI_TOKEN"]
 
         client = InferenceClient(model=model_url, token=token)
-        self.llm = partial(client.text_generation, max_new_tokens=max_new_tokens)
+        self.llm = partial(client.text_generation, max_new_tokens=max_new_tokens, details=log_probs)

--- a/src/agentlab/llm/huggingface_utils.py
+++ b/src/agentlab/llm/huggingface_utils.py
@@ -100,7 +100,10 @@ class HFBaseChatModel(AbstractChatModel):
             while True:
                 try:
                     temperature = temperature if temperature is not None else self.temperature
-                    response = AIMessage(self.llm(prompt, temperature=temperature))
+                    answer = self.llm(prompt, temperature=temperature)
+                    response = AIMessage(answer)
+                    if hasattr(answer, "details"):
+                        response["log_prob"] = answer.details.log_prob
                     responses.append(response)
                     break
                 except Exception as e:

--- a/src/agentlab/llm/llm_utils.py
+++ b/src/agentlab/llm/llm_utils.py
@@ -383,6 +383,10 @@ def image_to_jpg_base64_url(image: np.ndarray | Image.Image):
 
 class BaseMessage(dict):
     def __init__(self, role: str, content: Union[str, list[dict]], **kwargs):
+        allowed_attrs = {"log_probs"}
+        invalid_attrs = set(kwargs.keys()) - allowed_attrs
+        if invalid_attrs:
+            raise ValueError(f"Invalid attributes: {invalid_attrs}")
         self["role"] = role
         self["content"] = deepcopy(content)
         self.update(kwargs)
@@ -465,8 +469,8 @@ class HumanMessage(BaseMessage):
 
 
 class AIMessage(BaseMessage):
-    def __init__(self, content: Union[str, list[dict]]):
-        super().__init__("assistant", content)
+    def __init__(self, content: Union[str, list[dict]], log_probs=None):
+        super().__init__("assistant", content, log_probs=log_probs)
 
 
 class Discussion:

--- a/src/agentlab/llm/llm_utils.py
+++ b/src/agentlab/llm/llm_utils.py
@@ -382,9 +382,10 @@ def image_to_jpg_base64_url(image: np.ndarray | Image.Image):
 
 
 class BaseMessage(dict):
-    def __init__(self, role: str, content: Union[str, list[dict]]):
+    def __init__(self, role: str, content: Union[str, list[dict]], **kwargs):
         self["role"] = role
         self["content"] = deepcopy(content)
+        self.update(kwargs)
 
     def __str__(self, warn_if_image=False) -> str:
         if isinstance(self["content"], str):


### PR DESCRIPTION
With this option on (in LLM configs), the chat_messages will also save log-probabilities that will be saved along with the outputs.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add an option to compute and include log probabilities (`log_probs`) in chat model responses.

### Why are these changes being made?

These changes allow users to obtain log probabilities of the generated tokens, enabling more detailed analysis and interpretability of the model's outputs. This feature can be essential for tasks that require understanding the model's confidence and decision-making process. The implementation involves propagating the `log_probs` parameter through various model initializations and calls without introducing breaking changes.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->