### PR TITLE
Add missing agent imports 

### DIFF
--- a/src/agentlab/agents/generic_agent/__init__.py
+++ b/src/agentlab/agents/generic_agent/__init__.py
@@ -16,7 +16,9 @@ from .agent_configs import (
     AGENT_4o,
     AGENT_4o_MINI,
     AGENT_CLAUDE_SONNET_35,
+    AGENT_CLAUDE_SONNET_35_VISION,
     AGENT_4o_VISION,
+    AGENT_4o_MINI_VISION,
     AGENT_o3_MINI,
     AGENT_o1_MINI,
 )


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add missing imports for `AGENT_CLAUDE_SONNET_35_VISION` and `AGENT_4o_MINI_VISION` to the `generic_agent` module initializer.

### Why are these changes being made?

These changes are being made to ensure that all relevant agents are available when the `generic_agent` module is imported. This fixes missing references that could lead to import errors or incomplete functionality in dependent modules.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->