### PR TITLE
fixing openai api typo for logprobs

### DIFF
--- a/src/agentlab/llm/chat_api.py
+++ b/src/agentlab/llm/chat_api.py
@@ -292,7 +292,7 @@ class ChatModel(AbstractChatModel):
                     n=n_samples,
                     temperature=temperature,
                     max_tokens=self.max_tokens,
-                    log_probs=self.log_probs,
+                    logprobs=self.log_probs,
                 )
 
                 if completion.usage is None:


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix a typo in the OpenAI API call by replacing `log_probs` with `logprobs` in the `chat_api.py` file.

### Why are these changes being made?

This change corrects an incorrect parameter name in the API call which could have led to unexpected behavior or errors when retrieving log probabilities from the API. The adjustment aligns with the parameter naming conventions of the OpenAI API.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->