### PR TITLE
typo in hf chat models

### DIFF
--- a/src/agentlab/llm/huggingface_utils.py
+++ b/src/agentlab/llm/huggingface_utils.py
@@ -2,11 +2,12 @@ import logging
 import time
 from typing import Any, List, Optional, Union
 
+from pydantic import Field
+from transformers import AutoTokenizer, GPT2TokenizerFast
+
 from agentlab.llm.base_api import AbstractChatModel
 from agentlab.llm.llm_utils import AIMessage, Discussion
 from agentlab.llm.prompt_templates import PromptTemplate, get_prompt_template
-from pydantic import Field
-from transformers import AutoTokenizer, GPT2TokenizerFast
 
 
 class HFBaseChatModel(AbstractChatModel):
@@ -104,7 +105,7 @@ class HFBaseChatModel(AbstractChatModel):
                     response = AIMessage(answer)
                     if self.log_probs:
                         response["content"] = answer.generated_text
-                        response["log_prob"] = answer.details
+                        response["log_probs"] = answer.details
                     responses.append(response)
                     break
                 except Exception as e:


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct a typo in the `HFBaseChatModel` class by renaming `log_prob` to `log_probs` and reorder import statements for consistency in `huggingface_utils.py`.

### Why are these changes being made?

The typo fix ensures consistency with variable naming conventions across the codebase, potentially preventing runtime errors or misinterpretations. The reordering of import statements improves code readability and adheres to the general Python style guide.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->