### PR TITLE
fixing stale test

### DIFF
--- a/tests/llm/test_tracking.py
+++ b/tests/llm/test_tracking.py
@@ -5,13 +5,9 @@ from functools import partial
 import pytest
 
 import agentlab.llm.tracking as tracking
-from agentlab.llm.chat_api import (
-    AzureChatModel,
-    OpenAIChatModel,
-    OpenRouterChatModel,
-    make_system_message,
-    make_user_message,
-)
+from agentlab.llm.chat_api import (AzureChatModel, OpenAIChatModel,
+                                   OpenRouterChatModel, make_system_message,
+                                   make_user_message)
 
 
 def test_get_action_decorator():
@@ -37,7 +33,6 @@ OPENROUTER_MODELS = (
     "meta-llama/llama-3.1-70b-instruct",
     "meta-llama/llama-3.1-8b-instruct",
     "google/gemini-pro-1.5",
-    "qwen/qwen-2-vl-72b-instruct",
 )
 
 

--- a/tests/llm/test_tracking.py
+++ b/tests/llm/test_tracking.py
@@ -5,9 +5,13 @@ from functools import partial
 import pytest
 
 import agentlab.llm.tracking as tracking
-from agentlab.llm.chat_api import (AzureChatModel, OpenAIChatModel,
-                                   OpenRouterChatModel, make_system_message,
-                                   make_user_message)
+from agentlab.llm.chat_api import (
+    AzureChatModel,
+    OpenAIChatModel,
+    OpenRouterChatModel,
+    make_system_message,
+    make_user_message,
+)
 
 
 def test_get_action_decorator():


### PR DESCRIPTION
Test uses outdated model in openrouter

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the import formatting and a stale test model item from the test file `test_tracking.py`.

### Why are these changes being made?

The import statement formatting was adjusted for consistency and readability, and the test model entry "qwen/qwen-2-vl-72b-instruct" was removed because it was no longer relevant, likely due to updates in the models being tested or its current unavailability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->