### PR TITLE
Update cost-tracking for OAI chatcompletions and response API

### DIFF
--- a/src/agentlab/llm/tracking.py
+++ b/src/agentlab/llm/tracking.py
@@ -163,6 +163,10 @@ class TrackAPIPricingMixin:
         response = self._call_api(*args, **kwargs)
 
         usage = dict(getattr(response, "usage", {}))
+        if 'prompt_tokens_details' in usage:
+            usage['cached_tokens'] = usage['prompt_token_details'].cached_tokens
+        if 'input_tokens_details' in usage:
+            usage['cached_tokens'] = usage['input_tokens_details'].cached_tokens
         usage = {f"usage_{k}": v for k, v in usage.items() if isinstance(v, (int, float))}
         usage |= {"n_api_calls": 1}
         usage |= {"effective_cost": self.get_effective_cost(response)}
@@ -298,21 +302,29 @@ class TrackAPIPricingMixin:
         Returns:
             float: The effective cost calculated from the response.
         """
-        usage = getattr(response, "usage", {})
-        prompt_token_details = getattr(response, "prompt_tokens_details", {})
-
-        total_input_tokens = getattr(
-            prompt_token_details, "prompt_tokens", 0
-        )  # Cache read tokens + new input tokens
-        output_tokens = getattr(usage, "completion_tokens", 0)
-        cache_read_tokens = getattr(prompt_token_details, "cached_tokens", 0)
-
-        non_cached_input_tokens = total_input_tokens - cache_read_tokens
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            logging.warning("No usage information found in the response. Defaulting cost to 0.0.")
+            return 0.0
+        api_type = 'chatcompletion' if hasattr(usage, "prompt_tokens_details") else 'response'
+        if api_type == 'chatcompletion':
+            total_input_tokens = usage.prompt_tokens
+            output_tokens = usage.completion_tokens
+            cached_input_tokens = usage.prompt_tokens_details.cached_tokens
+            non_cached_input_tokens = total_input_tokens - cached_input_tokens
+        elif api_type == 'response':
+            total_input_tokens = usage.input_tokens
+            output_tokens = usage.output_tokens
+            cached_input_tokens = usage.input_tokens_details.cached_tokens
+            non_cached_input_tokens = total_input_tokens - cached_input_tokens
+        else:
+            logging.warning(f"Unsupported API type: {api_type}. Defaulting cost to 0.0.")
+            return 0.0
+        
         cache_read_cost = self.input_cost * OPENAI_CACHE_PRICING_FACTOR["cache_read_tokens"]
-
         effective_cost = (
             self.input_cost * non_cached_input_tokens
-            + cache_read_tokens * cache_read_cost
+            + cached_input_tokens * cache_read_cost
             + self.output_cost * output_tokens
         )
         return effective_cost

--- a/src/agentlab/llm/tracking.py
+++ b/src/agentlab/llm/tracking.py
@@ -163,10 +163,10 @@ class TrackAPIPricingMixin:
         response = self._call_api(*args, **kwargs)
 
         usage = dict(getattr(response, "usage", {}))
-        if 'prompt_tokens_details' in usage:
-            usage['cached_tokens'] = usage['prompt_token_details'].cached_tokens
-        if 'input_tokens_details' in usage:
-            usage['cached_tokens'] = usage['input_tokens_details'].cached_tokens
+        if "prompt_tokens_details" in usage:
+            usage["cached_tokens"] = usage["prompt_token_details"].cached_tokens
+        if "input_tokens_details" in usage:
+            usage["cached_tokens"] = usage["input_tokens_details"].cached_tokens
         usage = {f"usage_{k}": v for k, v in usage.items() if isinstance(v, (int, float))}
         usage |= {"n_api_calls": 1}
         usage |= {"effective_cost": self.get_effective_cost(response)}
@@ -306,13 +306,13 @@ class TrackAPIPricingMixin:
         if usage is None:
             logging.warning("No usage information found in the response. Defaulting cost to 0.0.")
             return 0.0
-        api_type = 'chatcompletion' if hasattr(usage, "prompt_tokens_details") else 'response'
-        if api_type == 'chatcompletion':
+        api_type = "chatcompletion" if hasattr(usage, "prompt_tokens_details") else "response"
+        if api_type == "chatcompletion":
             total_input_tokens = usage.prompt_tokens
             output_tokens = usage.completion_tokens
             cached_input_tokens = usage.prompt_tokens_details.cached_tokens
             non_cached_input_tokens = total_input_tokens - cached_input_tokens
-        elif api_type == 'response':
+        elif api_type == "response":
             total_input_tokens = usage.input_tokens
             output_tokens = usage.output_tokens
             cached_input_tokens = usage.input_tokens_details.cached_tokens
@@ -320,7 +320,7 @@ class TrackAPIPricingMixin:
         else:
             logging.warning(f"Unsupported API type: {api_type}. Defaulting cost to 0.0.")
             return 0.0
-        
+
         cache_read_cost = self.input_cost * OPENAI_CACHE_PRICING_FACTOR["cache_read_tokens"]
         effective_cost = (
             self.input_cost * non_cached_input_tokens


### PR DESCRIPTION
This pull request refines token usage tracking and cost calculation logic in the `src/agentlab/llm/tracking.py` file. The changes improve handling of cached tokens and introduce better differentiation between API types (`chatcompletion` vs. `response`) for more accurate cost computation.

### Enhancements to token usage tracking:

* [`src/agentlab/llm/tracking.py`](diffhunk://#diff-67e9b3e6c61a16aae3305db5b90983141194a249a8dc7d38e84d4a7f41f2a8dfR166-R169): Updated the `__call__` method to extract and include `cached_tokens` from `prompt_tokens_details` or `input_tokens_details` in the usage dictionary, ensuring more precise tracking of cached token usage.

### Improvements to cost calculation logic:

* [`src/agentlab/llm/tracking.py`](diffhunk://#diff-67e9b3e6c61a16aae3305db5b90983141194a249a8dc7d38e84d4a7f41f2a8dfL301-R327): Refactored the `get_effective_cost_from_openai_api` method to handle two distinct API types (`chatcompletion` and `response`). Added logic to compute `cached_input_tokens` and `non_cached_input_tokens` separately for each type, improving the accuracy of effective cost calculations. Introduced warnings for missing usage information or unsupported API types.…ponses API

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add detailed cost-tracking for OAI chatcompletions and response APIs by handling both prompt and input token details and updating the calculation logic for effective cost.

### Why are these changes being made?

These changes are introduced to accurately track and calculate the cost associated with API calls for chatcompletions and responses by considering cached token details. This enhances billing transparency and allows for a more precise cost calculation, particularly reflecting actual usage and caching contributions. Handling `None` cases for usage information ensures robust and error-free cost calculations.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->