### PR TITLE
Update relaunch flag to False and adjust model_args for OSWORLD_OAI

### DIFF
--- a/experiments/run_osworld.py
+++ b/experiments/run_osworld.py
@@ -28,7 +28,7 @@ def get_task_ids() -> set[str]:
 def main():
     n_jobs = 4
     use_vmware = True
-    relaunch = True
+    relaunch = False
     agent_args = [
         OSWORLD_CLAUDE,
         #    OSWORLD_OAI # performs poorly.

--- a/src/agentlab/agents/tool_use_agent/tool_use_agent.py
+++ b/src/agentlab/agents/tool_use_agent/tool_use_agent.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any
 
 import bgym
-import numpy as np
 import pandas as pd
+from bgym import Benchmark as BgymBenchmark
 from browsergym.core.observation import extract_screenshot
 from browsergym.utils.obs import (
     flatten_axtree_to_str,
@@ -16,12 +16,9 @@ from browsergym.utils.obs import (
     overlay_som,
     prune_html,
 )
-from PIL import Image
 
-from agentlab.agents import agent_utils
-from agentlab.benchmarks.abstract_env import AbstractBenchmark as AgentLabBenchmark
-from bgym import Benchmark as BgymBenchmark
 from agentlab.agents.agent_args import AgentArgs
+from agentlab.benchmarks.abstract_env import AbstractBenchmark as AgentLabBenchmark
 from agentlab.benchmarks.osworld import OSWorldActionSet
 from agentlab.llm.base_api import BaseModelArgs
 from agentlab.llm.llm_utils import image_to_png_base64_url
@@ -629,7 +626,7 @@ OSWORLD_CLAUDE = ToolUseAgentArgs(
 )
 
 OSWORLD_OAI = ToolUseAgentArgs(
-    model_args=OPENAI_MODEL_CONFIG,
+    model_args=GPT_4_1_MINI,
     config=PromptConfig(
         tag_screenshot=True,
         goal=Goal(goal_as_system_msg=True),


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Set the relaunch flag to False in the OSWORLD experiment script and update the model arguments for the `OSWORLD_OAI` agent configuration to use `GPT_4_1_MINI` instead of `OPENAI_MODEL_CONFIG`.

### Why are these changes being made?
The relaunch is being disabled likely to prevent unnecessary restarts, optimizing resource management during testing. The model argument update aims to enhance the performance of the `OSWORLD_OAI` agent, as `OPENAI_MODEL_CONFIG` was identified to perform poorly. The organization of imports in the `tool_use_agent.py` file is also improved for readability by removing unused imports and restructuring existing ones.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->