### PR TITLE
Fix: cache breakpoint handling in StructuredDiscussion class.

### DIFF
--- a/src/agentlab/agents/tool_use_agent/tool_use_agent.py
+++ b/src/agentlab/agents/tool_use_agent/tool_use_agent.py
@@ -101,8 +101,10 @@ class StructuredDiscussion:
                 messages.extend(group.messages)
             # Mark all summarized messages for caching
             if i == len(self.groups) - keep_last_n_obs:
-                if not isinstance(messages[i], ToolCalls):
-                    messages[i].mark_all_previous_msg_for_caching()
+                for msg in messages:  # unset previous cache breakpoints
+                    msg._cache_breakpoint = False
+                # set new cache breakpoint
+                messages[i].mark_all_previous_msg_for_caching()
         return messages
 
     def set_last_summary(self, summary: MessageBuilder):


### PR DESCRIPTION
Anthropic requires maximum 4 cache breakpoints per request. This unsets cache breakpoints from earlier messages and only adds a single breakpoint in the flatten() method.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Refactor cache breakpoint handling by removing the check for `ToolCalls` and explicitly resetting cache breakpoints before setting new ones in the `flatten` method of the `StructuredDiscussion` class.

### Why are these changes being made?
This change ensures that cache breakpoints are managed consistently by clearing existing breakpoints before establishing new ones, thus preventing potential caching issues or stale breakpoints. The previous approach lacked explicit handling for clearing breakpoints, which could lead to incorrect caching behavior.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->