### PR TITLE
Fix loading exp_dir using row_index in xray and add error handling.

### DIFF
--- a/src/agentlab/analyze/agent_xray.py
+++ b/src/agentlab/analyze/agent_xray.py
@@ -103,7 +103,16 @@ class Info:
 
         # find unique row using idx
         result_df = self.agent_df.reset_index(inplace=False)
-        exp_dir = result_df.iloc[episode_id.row_index]["exp_dir"]
+        sub_df = result_df[result_df["_row_index"] == episode_id.row_index]
+        if len(sub_df) == 0:
+            self.exp_result = None
+            raise ValueError(f"Could not find _row_index: {episode_id.row_index}")
+
+        if len(sub_df) > 1:
+            warning(
+                f"Found multiple rows with same row_index {episode_id.row_index} Using the first one."
+            )
+        exp_dir = sub_df.iloc[0]["exp_dir"]
         print(exp_dir)
         self.exp_result = ExpResult(exp_dir)
         self.step = 0


### PR DESCRIPTION
Use _row_index column for getting exp_dir from agent_df instead of iloc. This fixes errors when multiple agents are loaded in result_df.
___
This pull request improves the robustness of the `update_exp_result` method in `agent_xray.py` by adding error handling and warnings for cases where the provided `row_index` is missing or duplicated in the DataFrame.

Error handling and data validation:

* Added logic to handle cases where no rows match the given `_row_index`, raising a `ValueError` and setting `self.exp_result` to `None`.
* Added a warning and fallback behavior when multiple rows have the same `_row_index`, using the first match.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Correct the loading mechanism for `exp_dir` using `row_index` in the `agent_xray.py` file and add error handling to warn when multiple or zero rows match the index.

### Why are these changes being made?

The previous approach could fail silently when multiple rows were returned or when there were no matches, leading to potential data inconsistencies. This addition ensures that only a single row is used for the `exp_dir`, and raises a `ValueError` when no rows match, improving the robustness of data retrieval and processing in the code.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->