### PR TITLE
increase timeout indefinetely in agentlab-mentor

### DIFF
--- a/src/agentlab/agents/hitl_agent/generic_human_guided_agent.py
+++ b/src/agentlab/agents/hitl_agent/generic_human_guided_agent.py
@@ -245,7 +245,7 @@ class MultipleProposalGenericAgent(GenericAgent):
                 )
 
                 self.ui.update_context(hint_labeling_inputs)
-                response = self.ui.wait_for_response(timeout=600)
+                response = self.ui.wait_for_response(timeout=None)
 
                 if response["type"] == "reprompt":
                     new_hints = response["payload"].get("hints", [])

--- a/src/agentlab/agents/hitl_agent/hitl_agent.py
+++ b/src/agentlab/agents/hitl_agent/hitl_agent.py
@@ -75,7 +75,7 @@ class HumanInTheLoopAgent(Agent):
                 )
 
                 self.ui.update_context(hint_labeling_inputs)
-                response = self.ui.wait_for_response(timeout=600)
+                response = self.ui.wait_for_response(timeout=None)
 
                 if response["type"] == "reprompt":
                     new_hints = response["payload"].get("hints", [])


### PR DESCRIPTION
This pull request removes the timeout for waiting on user responses in both the `generic_human_guided_agent.py` and `hitl_agent.py` agents. Now, the system will wait indefinitely for user input instead of timing out after 600 seconds.

User input handling:

* Changed the `wait_for_response` method in both `generic_human_guided_agent.py` and `hitl_agent.py` to wait indefinitely for user responses by setting `timeout=None` instead of a 600-second timeout. [[1]](diffhunk://#diff-fd2e4b4ed9cf3ab46986fab2bae20b169eb19227377c4bde9f60a63322419cceL248-R248) [[2]](diffhunk://#diff-215d5e9bc4a6112002c6ad3ef43248a1fb8afd3ef5076fb5188fd96ee01d2342L78-R78)