### PR TITLE
Allow custom VLLM endpoint URL

### DIFF
--- a/src/agentlab/llm/chat_api.py
+++ b/src/agentlab/llm/chat_api.py
@@ -479,7 +479,7 @@ class VLLMChatModel(ChatModel):
             min_retry_wait_time=min_retry_wait_time,
             api_key_env_var="VLLM_API_KEY",
             client_class=OpenAI,
-            client_args={"base_url": "http://0.0.0.0:8000/v1"},
+            client_args={"base_url": os.getenv("VLLM_API_URL", "http://localhost:8000/v1")},
             pricing_func=None,
         )
 


### PR DESCRIPTION
When deploying a VLLM server on a different Node/GPU than the one we are using when running agents, the base URL for the endpoint cannot be `http://0.0.0.0:8000`. 

https://github.com/ServiceNow/AgentLab/blob/da8cb7cccb411b261121e4e1511364a103a284c4/src/agentlab/llm/chat_api.py#L463-L482

This PR introduces a new environment variable `VLLM_API_URL` that allows to use a custom endpoint URL or fall back to the default local server.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Allow configuring the VLLM endpoint URL via environment variable VLLM_API_URL, defaulting to http://localhost:8000/v1 if not set.

### Why are these changes being made?
To enable configuring the VLLM backend URL without code changes, using a sensible default when the variable is not provided.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->