### PR TITLE
Fix incorrect references for docs retrieval hinter agent

### DIFF
--- a/src/agentlab/agents/hint_use_agent/generic_agent.py
+++ b/src/agentlab/agents/hint_use_agent/generic_agent.py
@@ -272,7 +272,9 @@ does not support vision. Disabling use_screenshot."""
         try:
             if self.flags.hint_type == "docs":
                 if self.flags.hint_index_type == "direct":
-                    print("WARNING: Hint index type 'direct' is not supported for docs. Using 'sparse' instead.")
+                    print(
+                        "WARNING: Hint index type 'direct' is not supported for docs. Using 'sparse' instead."
+                    )
                     self.flags.hint_index_type = "sparse"
                 if self.flags.hint_index_type == "sparse":
                     import bm25s
@@ -327,7 +329,9 @@ does not support vision. Disabling use_screenshot."""
 
         if self.flags.hint_type == "docs":
             if self.flags.hint_index_type == "direct":
-                print("WARNING: Hint index type 'direct' is not supported for docs. Using 'sparse' instead.")
+                print(
+                    "WARNING: Hint index type 'direct' is not supported for docs. Using 'sparse' instead."
+                )
                 self.flags.hint_index_type = "sparse"
             if not hasattr(self, "hint_index"):
                 print("WARNING: Hint index not initialized. Initializing now.")


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix incorrect references for docs retrieval hinter agent and align hint retrieval flow across the docs hinter integration.

- Introduce and wire up HintsSource-based hint retrieval for the hinter agent, including embedding/direct/LLM-backed modes.
- Update hinter agent initialization and prompt construction to properly use task hints and docs-based retrieval.
- Add and adjust configuration and prompt utilities (GenericAgentArgs, GenericPromptFlags, BASE_FLAGS) to support correct hinter behavior.
- Rename/redirect older hinter module import paths to a new module path and maintain backward compatibility (deprecation warning and aliasing).
- Update supporting scripts and entry points to reflect corrected hinter behavior (run scripts and related sh files).
- Minor fixes to agent and utility modules to ensure compatibility with the new hinter workflow (e.g., prompt construction, hint injection, and parsing).

### Why are these changes being made?

To correct broken references and integration points in the docs retrieval hinter flow, ensuring the hinter agent reliably fetches and uses relevant hints from the docs source and aligns with the updated prompt construction and configuration. This improves reliability of hint-based guidance and consistency across agent variants.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->