### PR TITLE
docs: reference ClawBench as an external live-web benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ AgentLab Features:
 | [OSWorld](https://os-world.github.io/) | [setup](https://github.com/ServiceNow/AgentLab/blob/main/src/agentlab/benchmarks/osworld.md) | 369 | None | - | - | self hosted  | soon |
 | [TimeWarp](https://timewarp-web.github.io/) | [setup](https://github.com/sparklabutah/timewarp) | 1386 | None | 30 | yes | self hosted | soon |
 
+## 📎 External live-web benchmarks
+
+The following independent benchmark is useful for evaluating web and computer-use agents, but is not currently integrated with or supported by AgentLab:
+
+* **[ClawBench](https://github.com/reacher-z/ClawBench)** — [paper](https://arxiv.org/abs/2604.08523) and [project page](https://claw-bench.com/). It evaluates agents on 283 tasks across 163 live platforms using isolated browser sessions, request-level outcome checks, and recorded action, screenshot, network, and message traces. See the project's own [runner and setup instructions](https://github.com/reacher-z/ClawBench#readme) for execution details. Task definitions are available on [Hugging Face](https://huggingface.co/datasets/NAIL-Group/ClawBench) and mirrored at [TIGER-Lab/ClawBench](https://huggingface.co/datasets/TIGER-Lab/ClawBench).
+
 
 ## 🛠️ Setup AgentLab
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ AgentLab Features:
 
 The following independent benchmark is useful for evaluating web and computer-use agents, but is not currently integrated with or supported by AgentLab:
 
-* **[ClawBench](https://github.com/reacher-z/ClawBench)** — [paper](https://arxiv.org/abs/2604.08523) and [project page](https://claw-bench.com/). It evaluates agents on 283 tasks across 163 live platforms using isolated browser sessions, request-level outcome checks, and recorded action, screenshot, network, and message traces. See the project's own [runner and setup instructions](https://github.com/reacher-z/ClawBench#readme) for execution details. Task definitions are available on [Hugging Face](https://huggingface.co/datasets/NAIL-Group/ClawBench) and mirrored at [TIGER-Lab/ClawBench](https://huggingface.co/datasets/TIGER-Lab/ClawBench).
+* **[ClawBench](https://github.com/TIGER-AI-Lab/ClawBench)** — [paper](https://arxiv.org/abs/2604.08523) and [project page](https://claw-bench.com/). It evaluates agents on 283 tasks across 163 live platforms using isolated browser sessions, request-level outcome checks, and recorded action, screenshot, network, and message traces. See the project's own [runner and setup instructions](https://github.com/TIGER-AI-Lab/ClawBench#readme) for execution details. Task definitions are available on [Hugging Face](https://huggingface.co/datasets/NAIL-Group/ClawBench) and mirrored at [TIGER-Lab/ClawBench](https://huggingface.co/datasets/TIGER-Lab/ClawBench).
 
 
 ## 🛠️ Setup AgentLab


### PR DESCRIPTION
## Summary

Adds a clearly labeled external benchmark reference near AgentLab's supported-benchmark documentation.

ClawBench is described neutrally with links to its paper, code, project page, and task-definition datasets. The entry explicitly states that it is not integrated with or supported by AgentLab, so it does not change AgentLab benchmark support claims.

## Verification

- Documentation-only change to `README.md`
- `git diff --check` passes
- Submitted by `reacher-z`, a ClawBench maintainer; this text was prepared with OpenAI Codex assistance
- Maintainer edits are enabled on the fork

Closes no issue.